### PR TITLE
replace yaku with es6-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "yaku": "^0.19.3"
+    "es6-promise": "^4.2.8"
   },
   "standard": {
     "env": [

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -1,4 +1,4 @@
-import Promise from 'yaku/lib/yaku.core'
+import Promise from 'es6-promise'
 import firebase from 'firebase/app'
 import 'firebase/auth'
 import 'firebase/database'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,6 +1965,11 @@ es6-promise@^4.0.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
+es6-promise@^4.2.8:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
 es6-promisify@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
@@ -5643,10 +5648,6 @@ xtend@~2.1.1:
 y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
-yaku@^0.19.3:
-  version "0.19.3"
-  resolved "https://registry.yarnpkg.com/yaku/-/yaku-0.19.3.tgz#886edda49b27ac98061bb8bdc7d56543c4dc61d1"
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## Why
the [implementation of yaku](https://github.com/ysmood/yaku/blob/master/src/yaku.core.js#L47) does not support `react-native` env very well. instead of [adding polyfill](https://stackoverflow.com/questions/34845760/process-nexttick-is-not-a-function-react-native-ddp-meteor) by ourselves, I'll prefer just use other mature solution.